### PR TITLE
fix: hardening de defectos (datasource/JWT por DI, secretos fail-fast, tipos, logging)

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -15,4 +15,6 @@ DB_USER=sa
 DB_PASSWORD=StrongPassword123!
 DB_NAME=testdb
 #LOG
+#Logger implementation: "pino" (default) | "winston"
+LOG_DRIVER=pino
 LOG_LEVEL=trace

--- a/.env.dev
+++ b/.env.dev
@@ -5,6 +5,8 @@ SERVICE_NAME=ApiTSExpress
 API_VERSION=1.0.0
 # Auth
 JWT_SECRET=change_me_super_secret
+#DataSource: "dummy" (in-memory, default) | "sqlserver"
+DATA_SOURCE=dummy
 #DB
 DB_DIALECT=mssql
 DB_HOST=localhost

--- a/.env.template
+++ b/.env.template
@@ -16,4 +16,6 @@ DB_USER=sa
 DB_PASSWORD=change_me
 DB_NAME=testdb
 #LOG
+#Logger implementation: "pino" (default) | "winston"
+LOG_DRIVER=pino
 LOG_LEVEL=trace

--- a/.env.template
+++ b/.env.template
@@ -5,6 +5,8 @@ SERVICE_NAME=ApiTSExpress
 API_VERSION=1.0.0
 # Auth
 JWT_SECRET=change_me_super_secret
+#DataSource: "dummy" (in-memory, default) | "sqlserver"
+DATA_SOURCE=dummy
 #DB
 DB_DIALECT=mssql
 DB_HOST=localhost

--- a/.env.template
+++ b/.env.template
@@ -12,7 +12,8 @@ DB_DIALECT=mssql
 DB_HOST=localhost
 DB_PORT=1434
 DB_USER=sa
-DB_PASSWORD=StrongPassword123!
+# Required only when DATA_SOURCE=sqlserver. The app fails to start if missing.
+DB_PASSWORD=change_me
 DB_NAME=testdb
 #LOG
 LOG_LEVEL=trace

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -41,9 +41,19 @@ In development (`NODE_ENV=development`), logs are pretty-printed via pino-pretty
 
 ---
 
+## Data source selection
+
+The `IUsersDataSource` implementation is selected at startup via `DATA_SOURCE`.
+
+| Variable | Type | Default | Required | Description |
+|----------|------|---------|----------|-------------|
+| `DATA_SOURCE` | string | `dummy` | No | `dummy` (in-memory, no DB needed) or `sqlserver` (uses Sequelize). An unknown value fails fast at startup. |
+
+---
+
 ## Database (Sequelize)
 
-Only required when using `UsersSqlServerDataSource` (switched in `src/core/di/container.ts`).
+Only required when `DATA_SOURCE=sqlserver`. When `DATA_SOURCE=sqlserver`, `DB_PASSWORD` becomes a required secret (validated at startup).
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -27,7 +27,7 @@ Copy `.env.template` as a starting point.
 
 | Variable | Type | Default | Required | Description |
 |----------|------|---------|----------|-------------|
-| `JWT_SECRET` | string | — | **Yes** | Secret key for signing JWT tokens. Use a long random string in production. |
+| `JWT_SECRET` | string | — | **Yes** | Secret key for signing JWT tokens. Use a long random string in production. There is **no insecure default**: the app fails to start (loudly) if it is missing. |
 
 ---
 
@@ -95,11 +95,14 @@ JWT_SECRET=dev_secret_change_in_production
 # Logging
 LOG_LEVEL=trace
 
-# Database (only if using SQL Server datasource)
+# Data source: "dummy" (in-memory, default) or "sqlserver"
+DATA_SOURCE=dummy
+
+# Database (only if DATA_SOURCE=sqlserver)
 DB_DIALECT=mssql
 DB_HOST=localhost
 DB_PORT=1434
 DB_USER=sa
-DB_PASSWORD=StrongPassword123!
+DB_PASSWORD=change_me
 DB_NAME=testdb
 ```

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -35,9 +35,10 @@ Copy `.env.template` as a starting point.
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `LOG_LEVEL` | string | `trace` (dev) / `info` (prod) | Pino log level: `trace`, `debug`, `info`, `warn`, `error`, `fatal` |
+| `LOG_DRIVER` | string | `pino` | Logger implementation: `pino` (default, structured) or `winston`. An unknown value fails fast at startup. |
+| `LOG_LEVEL` | string | `trace` (dev) / `info` (prod) | Log level: `trace`, `debug`, `info`, `warn`, `error`, `fatal` |
 
-In development (`NODE_ENV=development`), logs are pretty-printed via pino-pretty. In other environments, logs are emitted as JSON.
+In development (`NODE_ENV=development`), Pino logs are pretty-printed via pino-pretty. In other environments, logs are emitted as JSON. Switching `LOG_DRIVER=winston` swaps the logger implementation without any code changes.
 
 ---
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,7 @@ module.exports = {
     "src/**/*.ts",
     "!src/main.ts",
     "!src/**/index.ts",
+    "!src/**/*.d.ts",
     "!src/core/di/container.ts",
     "!src/**/*.interface.ts",
     "!src/**/config/*.ts",

--- a/jest.config.js
+++ b/jest.config.js
@@ -57,5 +57,5 @@ module.exports = {
     },
   },
 
-  setupFiles: ["reflect-metadata"],
+  setupFiles: ["reflect-metadata", "<rootDir>/tests/setup/test-env.ts"],
 };

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # API Template — Node.js · Express 5 · TypeScript
 
-A production-ready REST API starter built with **Node.js**, **Express 5**, and **TypeScript**, following **Clean Architecture** principles. Swap databases, loggers, or storage backends by changing a single line in the DI container — every layer is independently testable.
+A production-ready REST API starter built with **Node.js**, **Express 5**, and **TypeScript**, following **Clean Architecture** principles. Swap the data source (`DATA_SOURCE`) or the logger (`LOG_DRIVER`) with a single environment variable — every layer is independently testable.
 
 ---
 
@@ -13,8 +13,8 @@ A production-ready REST API starter built with **Node.js**, **Express 5**, and *
 | Architecture | Clean Architecture (Presentation → Application → Domain → Infrastructure) |
 | Dependency Injection | tsyringe |
 | Authentication | JWT (Bearer token) |
-| Database | Sequelize + Tedious (SQL Server) with dummy in-memory fallback |
-| Logging | Pino (structured JSON) with pino-pretty in development |
+| Database | Sequelize + Tedious (SQL Server) or dummy in-memory — selected via `DATA_SOURCE` |
+| Logging | Pino (structured JSON, pino-pretty in dev) or Winston — selected via `LOG_DRIVER` |
 | API Docs | Swagger UI + Scalar |
 | File Storage | Local filesystem or AWS S3 / MinIO |
 | Testing | Jest — unit, integration |
@@ -105,13 +105,15 @@ Copy `.env.template` to `.env.dev` (development) or `.env` (production) and fill
 | `NODE_ENV` | `development` | `development` / `production` / `test` |
 | `SERVICE_NAME` | `ApiTSExpress` | Service name in logs |
 | `API_VERSION` | `1.0.0` | Shown in Swagger |
-| `JWT_SECRET` | — | **Required.** Sign JWT tokens |
-| `LOG_LEVEL` | `trace` | Pino log level |
+| `JWT_SECRET` | — | **Required.** Sign JWT tokens. No insecure default — the app fails fast at startup if missing |
+| `DATA_SOURCE` | `dummy` | Users data source: `dummy` (in-memory) / `sqlserver` |
+| `LOG_DRIVER` | `pino` | Logger implementation: `pino` / `winston` |
+| `LOG_LEVEL` | `trace` | Log level |
 | `DB_DIALECT` | `mssql` | `mssql` / `mysql` / `postgres` |
 | `DB_HOST` | `localhost` | Database host |
 | `DB_PORT` | `1434` | Database port |
 | `DB_USER` | `sa` | Database user |
-| `DB_PASSWORD` | — | Database password |
+| `DB_PASSWORD` | — | Database password. Required (fails fast) when `DATA_SOURCE=sqlserver` |
 | `DB_NAME` | `testdb` | Database name |
 
 Full reference: **[docs/environment.md](docs/environment.md)**.

--- a/src/application/services/users.service.ts
+++ b/src/application/services/users.service.ts
@@ -37,7 +37,10 @@ export class UsersService implements IUsersService {
   }
 
   async updateUser(id: number, user: Partial<UserDTO>): Promise<boolean> {
-    return await this.repository.updateUser(id, this.toModel(user as UserDTO));
+    // El id de la ruta identifica al usuario; el payload solo aporta los campos
+    // a actualizar. Mapeamos únicamente lo presente para no inventar un pkUser 0
+    // ni escribir un name undefined en un update parcial.
+    return await this.repository.updateUser(id, this.toPartialModel(user));
   }
 
   async deleteUser(id: number): Promise<boolean> {
@@ -50,5 +53,11 @@ export class UsersService implements IUsersService {
 
   private toModel(userDTO: UserDTO): IUser {
     return { pkUser: userDTO.id || 0, name: userDTO.name };
+  }
+
+  private toPartialModel(userDTO: Partial<UserDTO>): Partial<IUser> {
+    const model: Partial<IUser> = {};
+    if (userDTO.name !== undefined) model.name = userDTO.name;
+    return model;
   }
 }

--- a/src/core/config/env.validation.ts
+++ b/src/core/config/env.validation.ts
@@ -1,0 +1,32 @@
+// src/core/config/env.validation.ts
+import type { IEnvs } from "../../domain/interfaces/infrastructure/plugins/envs.plugin.interface";
+
+/**
+ * Valida que los secretos críticos estén presentes al arrancar la aplicación.
+ *
+ * En vez de degradarse silenciosamente con valores por defecto inseguros, la app
+ * falla de forma ruidosa (lanza un error) listando qué variables faltan.
+ *
+ * - `JWT_SECRET` es siempre obligatorio.
+ * - Los secretos de base de datos solo se exigen cuando `DATA_SOURCE=sqlserver`.
+ */
+export function validateCriticalEnvs(envs: IEnvs): void {
+  const missing: string[] = [];
+
+  if (!envs.getEnv("JWT_SECRET")) {
+    missing.push("JWT_SECRET");
+  }
+
+  if ((envs.getEnv("DATA_SOURCE") || "dummy").toLowerCase() === "sqlserver") {
+    if (!envs.getEnv("DB_PASSWORD")) {
+      missing.push("DB_PASSWORD");
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `[config] Missing required environment variable(s): ${missing.join(", ")}. ` +
+        "Refusing to start with insecure defaults. See docs/environment.md."
+    );
+  }
+}

--- a/src/core/config/swagger.config.ts
+++ b/src/core/config/swagger.config.ts
@@ -24,7 +24,7 @@ export const getSwaggerOptions = (): Options => {
         securitySchemes: {
           bearerAuth: {
             description:
-              'JWT Authorization header using the Bearer scheme. Example: "Authorization: Bearer {token}"',
+              "JWT Authorization header using the Bearer scheme. Example: \"Authorization: Bearer {token}\"",
             type: "http",
             scheme: "bearer",
             bearerFormat: "JWT",

--- a/src/core/di/container.ts
+++ b/src/core/di/container.ts
@@ -55,9 +55,9 @@ container.register<ISqlConnectionPlugin>("TestDB", {
   ),
 });
 
-container.register<IFileStorage>("IFileStorage",{
- useValue: new NativeFileStoragePlugin()
-})
+container.register<IFileStorage>("IFileStorage", {
+  useValue: new NativeFileStoragePlugin(),
+});
 // ========== DataSources =================
 // La implementación se selecciona vía la env var DATA_SOURCE ("dummy" | "sqlserver"),
 // con "dummy" por defecto en desarrollo.

--- a/src/core/di/container.ts
+++ b/src/core/di/container.ts
@@ -1,10 +1,10 @@
 // src/core/di/container.ts
 import "reflect-metadata";
 import { container } from "tsyringe";
-import { WinstonPlugin } from "../../infrastructure/plugins/winston.plugin";
 import { ILogger } from "../../domain/interfaces/infrastructure/plugins/logger.plugin.interface";
 import { IUsersDataSource } from "../../domain/interfaces/infrastructure/datasources/users.datasource.interface";
 import { resolveUsersDataSource } from "./datasource.factory";
+import { createLogger } from "./logger.factory";
 import { validateCriticalEnvs } from "../config/env.validation";
 import { IUsersRepository } from "../../domain/interfaces/infrastructure/repositories/users.repository.interface";
 import { UsersRepository } from "../../infrastructure/repositories/users.repository";
@@ -20,7 +20,6 @@ import { ISqlConnectionPlugin } from "../../domain/interfaces/infrastructure/plu
 import { SequelizePlugin } from "../../infrastructure/plugins/sequelize.plugin";
 import { IFileStorage } from "../../domain/interfaces/infrastructure/plugins/fileStorage.plugin.interface";
 import { NativeFileStoragePlugin } from "../../infrastructure/plugins/nativeFileStorage.plugin";
-import { PinoLoggerPlugin } from "../../infrastructure/plugins/pino.plugin";
 // ========== Plugins =================
 container.registerSingleton<IEnvs>("IEnvs", DotenvPlugin);
 
@@ -30,12 +29,10 @@ const envs:IEnvs = container.resolve("IEnvs");
 // silenciosamente con valores por defecto inseguros.
 validateCriticalEnvs(envs);
 
-// container.registerSingleton<ILogger>("ILogger", WinstonPlugin);
+// El logger se selecciona vía la env var LOG_DRIVER ("pino" | "winston"),
+// con "pino" por defecto. Winston queda disponible para conmutar cuando se quiera.
 container.register<ILogger>("ILogger", {
-  useValue: new PinoLoggerPlugin({
-    service: "api-ts-express",
-    level: envs.getEnv("LOG_LEVEL") || "debug",
-  }),
+  useValue: createLogger(envs),
 });
 
 

--- a/src/core/di/container.ts
+++ b/src/core/di/container.ts
@@ -5,6 +5,7 @@ import { WinstonPlugin } from "../../infrastructure/plugins/winston.plugin";
 import { ILogger } from "../../domain/interfaces/infrastructure/plugins/logger.plugin.interface";
 import { IUsersDataSource } from "../../domain/interfaces/infrastructure/datasources/users.datasource.interface";
 import { resolveUsersDataSource } from "./datasource.factory";
+import { validateCriticalEnvs } from "../config/env.validation";
 import { IUsersRepository } from "../../domain/interfaces/infrastructure/repositories/users.repository.interface";
 import { UsersRepository } from "../../infrastructure/repositories/users.repository";
 import { IUsersService } from "../../domain/interfaces/application/services/users.service.interface";
@@ -24,6 +25,11 @@ import { PinoLoggerPlugin } from "../../infrastructure/plugins/pino.plugin";
 container.registerSingleton<IEnvs>("IEnvs", DotenvPlugin);
 
 const envs:IEnvs = container.resolve("IEnvs");
+
+// Falla de forma ruidosa si faltan secretos críticos, en vez de degradarse
+// silenciosamente con valores por defecto inseguros.
+validateCriticalEnvs(envs);
+
 // container.registerSingleton<ILogger>("ILogger", WinstonPlugin);
 container.register<ILogger>("ILogger", {
   useValue: new PinoLoggerPlugin({
@@ -44,7 +50,7 @@ container.register<ISqlConnectionPlugin>("TestDB", {
     host: envs.getEnv("DB_HOST") || "localhost",
     port: Number(envs.getEnv("DB_PORT") || "1434"),
     username: envs.getEnv("DB_USER") || "sa",
-    password: envs.getEnv("DB_PASSWORD") || "StrongPassword123!",
+    password: envs.getEnv("DB_PASSWORD"),
     database: envs.getEnv("DB_NAME") || "testdb",
   }),
 });

--- a/src/core/di/container.ts
+++ b/src/core/di/container.ts
@@ -4,7 +4,7 @@ import { container } from "tsyringe";
 import { WinstonPlugin } from "../../infrastructure/plugins/winston.plugin";
 import { ILogger } from "../../domain/interfaces/infrastructure/plugins/logger.plugin.interface";
 import { IUsersDataSource } from "../../domain/interfaces/infrastructure/datasources/users.datasource.interface";
-import { UsersSqlServerDataSource } from "../../infrastructure/datasources/sqlserver/users.sqlserver.datasource";
+import { resolveUsersDataSource } from "./datasource.factory";
 import { IUsersRepository } from "../../domain/interfaces/infrastructure/repositories/users.repository.interface";
 import { UsersRepository } from "../../infrastructure/repositories/users.repository";
 import { IUsersService } from "../../domain/interfaces/application/services/users.service.interface";
@@ -17,10 +17,8 @@ import { ITokenPlugin } from "../../domain/interfaces/infrastructure/plugins/tok
 import { JwtPlugin } from "../../infrastructure/plugins/jwt.plugin";
 import { ISqlConnectionPlugin } from "../../domain/interfaces/infrastructure/plugins/sql.plugin.interface";
 import { SequelizePlugin } from "../../infrastructure/plugins/sequelize.plugin";
-import { UsersDummyDataSource } from "../../infrastructure/datasources/dummy/users.dummy.datasource";
 import { IFileStorage } from "../../domain/interfaces/infrastructure/plugins/fileStorage.plugin.interface";
 import { NativeFileStoragePlugin } from "../../infrastructure/plugins/nativeFileStorage.plugin";
-import path from "path";
 import { PinoLoggerPlugin } from "../../infrastructure/plugins/pino.plugin";
 // ========== Plugins =================
 container.registerSingleton<IEnvs>("IEnvs", DotenvPlugin);
@@ -55,7 +53,11 @@ container.register<IFileStorage>("IFileStorage",{
  useValue: new NativeFileStoragePlugin()
 })
 // ========== DataSources =================
-container.register<IUsersDataSource>("IUsersDataSource", { useClass: UsersDummyDataSource  });
+// La implementación se selecciona vía la env var DATA_SOURCE ("dummy" | "sqlserver"),
+// con "dummy" por defecto en desarrollo.
+container.register<IUsersDataSource>("IUsersDataSource", {
+  useClass: resolveUsersDataSource(envs.getEnv("DATA_SOURCE")),
+});
 
 // ========== Repositories =================
 

--- a/src/core/di/container.ts
+++ b/src/core/di/container.ts
@@ -45,14 +45,17 @@ container.register<ITokenPlugin>("ITokenPlugin", {
 });
 
 container.register<ISqlConnectionPlugin>("TestDB", {
-  useValue: new SequelizePlugin({
-    dialect: envs.getEnv("DB_DIALECT") || "mssql",
-    host: envs.getEnv("DB_HOST") || "localhost",
-    port: Number(envs.getEnv("DB_PORT") || "1434"),
-    username: envs.getEnv("DB_USER") || "sa",
-    password: envs.getEnv("DB_PASSWORD"),
-    database: envs.getEnv("DB_NAME") || "testdb",
-  }),
+  useValue: new SequelizePlugin(
+    {
+      dialect: envs.getEnv("DB_DIALECT") || "mssql",
+      host: envs.getEnv("DB_HOST") || "localhost",
+      port: Number(envs.getEnv("DB_PORT") || "1434"),
+      username: envs.getEnv("DB_USER") || "sa",
+      password: envs.getEnv("DB_PASSWORD"),
+      database: envs.getEnv("DB_NAME") || "testdb",
+    },
+    container.resolve<ILogger>("ILogger")
+  ),
 });
 
 container.register<IFileStorage>("IFileStorage",{

--- a/src/core/di/datasource.factory.ts
+++ b/src/core/di/datasource.factory.ts
@@ -1,0 +1,35 @@
+// src/core/di/datasource.factory.ts
+import { UsersDummyDataSource } from "../../infrastructure/datasources/dummy/users.dummy.datasource";
+import { UsersSqlServerDataSource } from "../../infrastructure/datasources/sqlserver/users.sqlserver.datasource";
+
+/**
+ * Implementaciones disponibles de IUsersDataSource, indexadas por el valor
+ * de la variable de entorno DATA_SOURCE.
+ */
+export const USERS_DATASOURCES: Record<
+  string,
+  typeof UsersDummyDataSource | typeof UsersSqlServerDataSource
+> = {
+  dummy: UsersDummyDataSource,
+  sqlserver: UsersSqlServerDataSource,
+};
+
+/**
+ * Resuelve la clase de datasource a registrar en el contenedor según el valor
+ * de DATA_SOURCE. Por defecto usa "dummy" (apto para desarrollo).
+ * Falla de forma ruidosa si el valor no corresponde a una implementación conocida.
+ */
+export function resolveUsersDataSource(name?: string) {
+  const key = (name || "dummy").toLowerCase();
+  const impl = USERS_DATASOURCES[key];
+
+  if (!impl) {
+    throw new Error(
+      `[config] Unknown DATA_SOURCE "${name}". Valid values: ${Object.keys(
+        USERS_DATASOURCES
+      ).join(", ")}.`
+    );
+  }
+
+  return impl;
+}

--- a/src/core/di/logger.factory.ts
+++ b/src/core/di/logger.factory.ts
@@ -1,0 +1,29 @@
+// src/core/di/logger.factory.ts
+import type { ILogger } from "../../domain/interfaces/infrastructure/plugins/logger.plugin.interface";
+import type { IEnvs } from "../../domain/interfaces/infrastructure/plugins/envs.plugin.interface";
+import { PinoLoggerPlugin } from "../../infrastructure/plugins/pino.plugin";
+import { WinstonPlugin } from "../../infrastructure/plugins/winston.plugin";
+
+export type LoggerDriver = "pino" | "winston";
+
+/**
+ * Crea la implementación de ILogger según la env var LOG_DRIVER
+ * ("pino" | "winston"), con "pino" por defecto. Permite conmutar de logger
+ * sin tocar el resto del cableado. Falla de forma ruidosa ante un valor desconocido.
+ */
+export function createLogger(envs: IEnvs): ILogger {
+  const driver = (envs.getEnv("LOG_DRIVER") || "pino").toLowerCase();
+  const level = envs.getEnv("LOG_LEVEL") || "debug";
+  const service = envs.getEnv("SERVICE_NAME") || "api-ts-express";
+
+  switch (driver) {
+    case "winston":
+      return new WinstonPlugin({ level, service });
+    case "pino":
+      return new PinoLoggerPlugin({ service, level });
+    default:
+      throw new Error(
+        `[config] Unknown LOG_DRIVER "${driver}". Valid values: pino, winston.`
+      );
+  }
+}

--- a/src/domain/interfaces/infrastructure/plugins/sql.plugin.interface.ts
+++ b/src/domain/interfaces/infrastructure/plugins/sql.plugin.interface.ts
@@ -1,28 +1,34 @@
 // src/infrastructure/plugins/isequelize.plugin.ts
 export interface ISqlConnectionPlugin {
   /**
-   * Equivalente a GetDataTable: devuelve un array de registros
+   * Equivalente a GetDataTable: devuelve un array de registros tipados.
    */
-  getDataTable(query: string, replacements?: any[]): Promise<any[]>;
+  getDataTable<TRow = Record<string, unknown>>(
+    query: string,
+    replacements?: unknown[]
+  ): Promise<TRow[]>;
 
   /**
-   * Ejecuta query (con o sin parámetros), retorna resultado crudo
+   * Ejecuta query (con o sin parámetros), retorna las filas y la metadata.
    */
-  executeQuery(
+  executeQuery<TRow = unknown, TMeta = unknown>(
     query: string,
-    replacements?: any[],
-    options?: any
-  ): Promise<{ rows: any; metadata: any }>;
+    replacements?: unknown[],
+    options?: Record<string, unknown>
+  ): Promise<{ rows: TRow; metadata: TMeta }>;
 
   /**
    * Ejecutar procedimiento almacenado con parámetros
    */
-  execStoredProcedure(spName: string, params?: any[]): Promise<any[]>;
+  execStoredProcedure<TRow = Record<string, unknown>>(
+    spName: string,
+    params?: unknown[]
+  ): Promise<TRow[]>;
 
   /**
    * Ejecutar un bloque dentro de una transacción
    */
-  transaction<T>(work: (t: any) => Promise<T>): Promise<T>;
+  transaction<T>(work: (t: unknown) => Promise<T>): Promise<T>;
 
   /**
    * Bulk insert con Sequelize

--- a/src/infrastructure/datasources/sqlserver/users.sqlserver.datasource.ts
+++ b/src/infrastructure/datasources/sqlserver/users.sqlserver.datasource.ts
@@ -6,6 +6,17 @@ import { IUser } from "../../../domain/models/users.model";
 import { SequelizePlugin } from "../../plugins/sequelize.plugin";
 import type { ILogger } from "../../../domain/interfaces/infrastructure/plugins/logger.plugin.interface";
 
+/** Forma de una fila de la tabla Users tal como la devuelve SQL Server. */
+interface UsersTableRow {
+  PKUser: number;
+  Name: string;
+  Available?: number;
+}
+
+function toMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 @injectable()
 export class UsersSqlServerDataSource implements IUsersDataSource {
   constructor(
@@ -14,71 +25,71 @@ export class UsersSqlServerDataSource implements IUsersDataSource {
   ) {
     this.db.authenticate().catch((err) => {
       this.logger.error("Error al autenticar con la base de datos", { err });
-      throw new Error(`[DataSource] Error al autenticar SequelizePlugin: ${err.message}`);
+      throw new Error(`[DataSource] Error al autenticar SequelizePlugin: ${toMessage(err)}`);
     });
   }
 
   async getAllUsers(page: number, limit: number): Promise<{ users: IUser[]; total: number }> {
     try {
       const offset = (page - 1) * limit;
-      const countResult = await this.db.executeQuery(
+      const countResult = await this.db.executeQuery<{ total: number }[]>(
         "SELECT COUNT(*) AS total FROM Users WHERE Available = 1"
       );
       const total = countResult.rows[0]?.total ?? 0;
 
       const query =
         "SELECT * FROM Users WHERE Available = 1 ORDER BY PKUser OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
-      const result = await this.db.executeQuery(query, [offset, limit]);
+      const result = await this.db.executeQuery<UsersTableRow[]>(query, [offset, limit]);
 
       this.logger.debug("getAllUsers ejecutado", { page, limit, total });
 
-      const users = result.rows.map((row: any) => ({
+      const users = result.rows.map((row) => ({
         pkUser: row.PKUser,
         name: row.Name,
       }));
 
       return { users, total };
-    } catch (err: any) {
+    } catch (err) {
       this.logger.error("Error en getAllUsers", { err });
-      throw new Error(`[DataSource] getAllUsers failed: ${err.message}`);
+      throw new Error(`[DataSource] getAllUsers failed: ${toMessage(err)}`);
     }
   }
 
   async getUserById(id: number): Promise<IUser | null> {
     try {
       const query = "SELECT * FROM Users WHERE PKUser = ? AND Available = 1";
-      const rows = await this.db.getDataTable(query, [id]);
+      const rows = await this.db.getDataTable<UsersTableRow>(query, [id]);
       if (rows.length === 0) return null;
       return { pkUser: rows[0].PKUser, name: rows[0].Name };
-    } catch (err: any) {
+    } catch (err) {
       this.logger.error("Error en getUserById", { id, err });
-      throw new Error(`[DataSource] getUserById failed for id=${id}: ${err.message}`);
+      throw new Error(`[DataSource] getUserById failed for id=${id}: ${toMessage(err)}`);
     }
   }
 
   async createUser(user: IUser): Promise<boolean> {
     try {
       const query = "INSERT INTO Users (Name) VALUES (?)";
-      const result = await this.db.executeQuery(query, [user.name]);
+      const result = await this.db.executeQuery<unknown, number>(query, [user.name]);
       const affected = result.metadata ?? 0;
       this.logger.info("Usuario creado", { user, affected });
       return affected > 0;
-    } catch (err: any) {
+    } catch (err) {
       this.logger.error("Error en createUser", { user, err });
-      throw new Error(`[DataSource] createUser failed: ${err.message}`);
+      throw new Error(`[DataSource] createUser failed: ${toMessage(err)}`);
     }
   }
 
   async updateUser(id: number, user: Partial<IUser>): Promise<boolean> {
     try {
       const query = "UPDATE Users SET Name = ? WHERE PKUser = ?";
-      const result = await this.db.executeQuery(query, [user.name, id]);
+      const result = await this.db.executeQuery<unknown, number>(query, [user.name, id]);
       const affected = result.metadata ?? 0;
       this.logger.info("Usuario actualizado", { id, user, affected });
       return affected > 0;
-    } catch (err: any) {
+    } catch (err) {
       this.logger.error("Error en updateUser", { id, user, err });
-      throw new Error(`[DataSource] updateUser failed for id=${id}: ${err.message}`);
+      throw new Error(`[DataSource] updateUser failed for id=${id}: ${toMessage(err)}`);
     }
   }
 
@@ -86,13 +97,13 @@ export class UsersSqlServerDataSource implements IUsersDataSource {
     try {
       const query =
         "UPDATE Users SET Available = 0 WHERE PKUser = ? AND Available = 1";
-      const result = await this.db.executeQuery(query, [id]);
+      const result = await this.db.executeQuery<unknown, number>(query, [id]);
       const affected = result.metadata ?? 0;
       this.logger.warn("Usuario marcado como eliminado", { id, affected });
       return affected > 0;
-    } catch (err: any) {
+    } catch (err) {
       this.logger.error("Error en deleteUser", { id, err });
-      throw new Error(`[DataSource] deleteUser failed for id=${id}: ${err.message}`);
+      throw new Error(`[DataSource] deleteUser failed for id=${id}: ${toMessage(err)}`);
     }
   }
 }

--- a/src/infrastructure/plugins/jwt.plugin.ts
+++ b/src/infrastructure/plugins/jwt.plugin.ts
@@ -10,7 +10,13 @@ export class JwtPlugin implements ITokenPlugin{
   private readonly secret: string;
 
   constructor(@inject("IEnvs") private readonly envs: IEnvs) {
-    this.secret = this.envs.getEnv("JWT_SECRET") || "super-secret-key";
+    const secret = this.envs.getEnv("JWT_SECRET");
+    if (!secret) {
+      throw new Error(
+        "[JwtPlugin] JWT_SECRET is not set. Refusing to sign tokens with an insecure default."
+      );
+    }
+    this.secret = secret;
   }
 
   /**

--- a/src/infrastructure/plugins/jwt.plugin.ts
+++ b/src/infrastructure/plugins/jwt.plugin.ts
@@ -57,7 +57,7 @@ export class JwtPlugin implements ITokenPlugin{
 
     try {
       const decoded = jwt.verify(token, this.secret);
-      (req as any).user = decoded; // attach al request
+      req.user = decoded; // attach al request
       next();
     } catch (error) {
       res.status(401).json({ error: "Invalid or expired token" });

--- a/src/infrastructure/plugins/jwt.plugin.ts
+++ b/src/infrastructure/plugins/jwt.plugin.ts
@@ -1,15 +1,16 @@
 // src/infrastructure/plugins/JwtPlugin.ts
 import { Request, Response, NextFunction } from "express";
 import jwt, { JwtPayload, SignOptions } from "jsonwebtoken";
+import { inject, injectable } from "tsyringe";
 import { ITokenPlugin } from "../../domain/interfaces/infrastructure/plugins/token.plugin.interface";
-import { IEnvs } from "../../domain/interfaces/infrastructure/plugins/envs.plugin.interface";
-import { container } from "tsyringe";
+import type { IEnvs } from "../../domain/interfaces/infrastructure/plugins/envs.plugin.interface";
 
+@injectable()
 export class JwtPlugin implements ITokenPlugin{
   private readonly secret: string;
-  private envs:IEnvs = container.resolve("IEnvs")
-  constructor(secret?: string) {
-    this.secret = secret || this.envs.getEnv("JWT_SECRET") || "super-secret-key";
+
+  constructor(@inject("IEnvs") private readonly envs: IEnvs) {
+    this.secret = this.envs.getEnv("JWT_SECRET") || "super-secret-key";
   }
 
   /**

--- a/src/infrastructure/plugins/sequelize.plugin.ts
+++ b/src/infrastructure/plugins/sequelize.plugin.ts
@@ -1,5 +1,5 @@
 // src/infrastructure/plugins/sequelize.connection.ts
-import { Sequelize, QueryTypes, Transaction, Options } from "sequelize";
+import { Sequelize, QueryTypes, Transaction, Options, QueryOptions } from "sequelize";
 import { ISqlConnectionPlugin } from "../../domain/interfaces/infrastructure/plugins/sql.plugin.interface";
 
 export interface SequelizeConnectionConfig {
@@ -36,42 +36,43 @@ export class SequelizePlugin implements ISqlConnectionPlugin {
   }
 
   /**
-   * Equivalente a GetDataTable: devuelve un array de registros
+   * Equivalente a GetDataTable: devuelve un array de registros tipados.
    */
-  async getDataTable(query: string, replacements: any[] = []): Promise<any[]> {
-    return await this.connection.query(query, {
+  async getDataTable<TRow = Record<string, unknown>>(
+    query: string,
+    replacements: unknown[] = []
+  ): Promise<TRow[]> {
+    return (await this.connection.query(query, {
       replacements,
       type: QueryTypes.SELECT,
-    });
+    })) as TRow[];
   }
 
   /**
-   * Ejecuta query (con o sin parámetros), retorna resultado crudo
+   * Ejecuta query (con o sin parámetros), retorna las filas y la metadata.
    */
-  async executeQuery(
+  async executeQuery<TRow = unknown, TMeta = unknown>(
     query: string,
-    replacements: any[] = [],
-    options: any = {}
-  ): Promise<any> {
-  // separar el resultado y las filas afectadas
-   const [rowsOrResult,metadata] = await this.connection.query(query, { replacements, ...options });
+    replacements: unknown[] = [],
+    options: Record<string, unknown> = {}
+  ): Promise<{ rows: TRow; metadata: TMeta }> {
+    // separar el resultado y la metadata (p.ej. filas afectadas en UPDATE/DELETE/INSERT)
+    const result = (await this.connection.query(query, {
+      replacements,
+      ...options,
+    } as QueryOptions)) as unknown as [TRow, TMeta];
 
-
-
-  // UPDATE/DELETE/INSERT → objeto con affectedRows
-  return {
-    rows: rowsOrResult,
-    metadata: metadata
-  };  
+    const [rowsOrResult, metadata] = result;
+    return { rows: rowsOrResult, metadata };
   }
 
   /**
    * Ejecutar procedimiento almacenado con parámetros (multi-dialecto)
    */
-  async execStoredProcedure(
+  async execStoredProcedure<TRow = Record<string, unknown>>(
     spName: string,
-    params: any[] = []
-  ): Promise<any[]> {
+    params: unknown[] = []
+  ): Promise<TRow[]> {
     const placeholders = params.map(() => "?").join(", ");
 
     let sql: string;
@@ -90,10 +91,10 @@ export class SequelizePlugin implements ISqlConnectionPlugin {
         );
     }
 
-    return await this.connection.query(sql, {
+    return (await this.connection.query(sql, {
       replacements: params,
       type: QueryTypes.SELECT,
-    });
+    })) as TRow[];
   }
 
   /**

--- a/src/infrastructure/plugins/sequelize.plugin.ts
+++ b/src/infrastructure/plugins/sequelize.plugin.ts
@@ -1,6 +1,7 @@
 // src/infrastructure/plugins/sequelize.connection.ts
 import { Sequelize, QueryTypes, Transaction, Options, QueryOptions } from "sequelize";
 import { ISqlConnectionPlugin } from "../../domain/interfaces/infrastructure/plugins/sql.plugin.interface";
+import type { ILogger } from "../../domain/interfaces/infrastructure/plugins/logger.plugin.interface";
 
 export interface SequelizeConnectionConfig {
   dialect: "mssql" | "mysql" | "mariadb" | "postgres"|string;
@@ -14,11 +15,17 @@ export interface SequelizeConnectionConfig {
 export class SequelizePlugin implements ISqlConnectionPlugin {
   private connection: Sequelize;
 
-  constructor(config: SequelizeConnectionConfig) {
+  constructor(
+    config: SequelizeConnectionConfig,
+    private readonly logger: ILogger
+  ) {
     this.connection = new Sequelize({
       ...config,
       pool: { max: 10, min: 0, idle: 10000 },
-      logging: process.env.NODE_ENV != "production" ? console.log : false,
+      logging:
+        process.env.NODE_ENV !== "production"
+          ? (sql: string) => this.logger.debug(sql)
+          : false,
     } as Options);
   }
 
@@ -28,9 +35,9 @@ export class SequelizePlugin implements ISqlConnectionPlugin {
   async authenticate(): Promise<void> {
     try {
       await this.connection.authenticate();
-      console.log("✅ Database connection established successfully.");
+      this.logger.info("Database connection established successfully.");
     } catch (error) {
-      console.error("❌ Unable to connect to the database:", error);
+      this.logger.error("Unable to connect to the database", { error });
       throw new Error("Database connection failed.");
     }
   }
@@ -130,7 +137,7 @@ export class SequelizePlugin implements ISqlConnectionPlugin {
     `;
 
     await this.connection.query(sql, { replacements: values });
-    console.log(`✅ Bulk insert: ${records.length} rows inserted into ${table}`);
+    this.logger.info(`Bulk insert: ${records.length} rows inserted into ${table}`);
   }
 
   /**
@@ -138,6 +145,6 @@ export class SequelizePlugin implements ISqlConnectionPlugin {
    */
   async close(): Promise<void> {
     await this.connection.close();
-    console.log("🔒 Database connection closed.");
+    this.logger.info("Database connection closed.");
   }
 }

--- a/src/infrastructure/plugins/winston.plugin.ts
+++ b/src/infrastructure/plugins/winston.plugin.ts
@@ -4,15 +4,25 @@ import path from "path";
 import { ILogger } from "../../domain/interfaces/infrastructure/plugins/logger.plugin.interface";
 import { injectable } from "tsyringe";
 
+export interface WinstonLoggerOptions {
+  level?: string;
+  service?: string;
+  logDir?: string;
+}
+
 @injectable()
 export class WinstonPlugin implements ILogger{
   private logger: winston.Logger;
+  private readonly logDir: string;
 
-  constructor() {
-    const level = "info";
+  constructor(opts: WinstonLoggerOptions = {}) {
+    const level = opts.level || process.env.LOG_LEVEL || "info";
+    const service = opts.service || process.env.SERVICE_NAME || "api";
+    this.logDir = opts.logDir || path.resolve(process.cwd(), "logs");
 
     this.logger = winston.createLogger({
       level,
+      defaultMeta: { service },
       format: winston.format.combine(
         winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
         // Formato para consola: color + legible
@@ -27,7 +37,7 @@ export class WinstonPlugin implements ILogger{
   }
 
   private getTransports(): winston.transport[] {
-    const logDir = path.resolve(__dirname, "../../logs");
+    const logDir = this.logDir;
     const transports: winston.transport[] = [
       new winston.transports.Console({
         format: winston.format.combine(

--- a/src/presentation/controllers/users.controller.ts
+++ b/src/presentation/controllers/users.controller.ts
@@ -13,7 +13,7 @@ export class UsersController implements IUsersController {
 
   public getAllUsers = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const { page, limit } = (req as any).validatedQuery ?? { page: 1, limit: 10 };
+      const { page, limit } = req.validatedQuery ?? { page: 1, limit: 10 };
       const result = await this.usersService.getAllUsers({ page, limit });
       res.json(result);
     } catch (err) {

--- a/src/presentation/middlewares/validate.middleware.ts
+++ b/src/presentation/middlewares/validate.middleware.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { ZodSchema } from "zod";
+import type { PaginationInput } from "../../application/validators/users.validators";
 
 export function validateBody(schema: ZodSchema) {
   return (req: Request, res: Response, next: NextFunction): void => {
@@ -34,7 +35,9 @@ export function validateQuery(schema: ZodSchema) {
       });
       return;
     }
-    (req as any).validatedQuery = result.data;
+    // validateQuery currently backs only the pagination query; the parsed
+    // output is typed as PaginationInput on the Request (see src/types/express.d.ts).
+    req.validatedQuery = result.data as PaginationInput;
     next();
   };
 }

--- a/src/presentation/routes/test.route.ts
+++ b/src/presentation/routes/test.route.ts
@@ -1,15 +1,16 @@
 // src/presentation/routes/test.route.ts
 
-import { JwtPlugin } from "../../infrastructure/plugins/jwt.plugin";
+import { ITokenPlugin } from "../../domain/interfaces/infrastructure/plugins/token.plugin.interface";
 import { Request, Response } from "express";
 import { NativeFileStoragePlugin } from "../../infrastructure/plugins/nativeFileStorage.plugin";
 import Busboy from "busboy";
 import { S3FileStoragePlugin } from "../../infrastructure/plugins/s3FileStorage.plugin";
+import { container } from "tsyringe";
 
 export class TestRoutes {
-  private jwtPlugin: JwtPlugin;
+  private jwtPlugin: ITokenPlugin;
   constructor() {
-    this.jwtPlugin = new JwtPlugin();
+    this.jwtPlugin = container.resolve<ITokenPlugin>("ITokenPlugin");
   }
 
   public register(app: any) {

--- a/src/presentation/routes/users.route.ts
+++ b/src/presentation/routes/users.route.ts
@@ -1,6 +1,6 @@
 // src/presentation/routes/user.routes.ts
 
-import { JwtPlugin } from "../../infrastructure/plugins/jwt.plugin";
+import { ITokenPlugin } from "../../domain/interfaces/infrastructure/plugins/token.plugin.interface";
 import { IUsersController } from "../../domain/interfaces/presentation/controllers/users.controller.interface";
 import { container } from "tsyringe";
 import { validateBody, validateQuery } from "../middlewares/validate.middleware";
@@ -8,10 +8,11 @@ import { createUserSchema, paginationSchema, updateUserSchema } from "../../appl
 
 export class UsersRoutes {
   private usersController: IUsersController;
-  private jwtPlugin: JwtPlugin = new JwtPlugin();
+  private jwtPlugin: ITokenPlugin;
 
   constructor() {
     this.usersController = container.resolve<IUsersController>("IUsersController");
+    this.jwtPlugin = container.resolve<ITokenPlugin>("ITokenPlugin");
   }
 
   public register(app: any) {

--- a/src/presentation/routes/users.route.ts
+++ b/src/presentation/routes/users.route.ts
@@ -63,6 +63,8 @@ export class UsersRoutes {
      *     tags:
      *       - Users
      *     summary: Get user by ID
+     *     security:
+     *       - bearerAuth: []
      *     parameters:
      *       - in: path
      *         name: id
@@ -76,10 +78,16 @@ export class UsersRoutes {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/User'
+     *       401:
+     *         description: Unauthorized
      *       404:
      *         description: User not found
      */
-    app.get("/users/:id", this.usersController.getUserById.bind(this.usersController));
+    app.get(
+      "/users/:id",
+      this.jwtPlugin.middleware,
+      this.usersController.getUserById.bind(this.usersController)
+    );
 
     /**
      * @openapi

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,17 @@
+// src/types/express.d.ts
+// Declaration merging to type the custom properties we attach to Express's Request:
+//  - `user`: the decoded JWT payload set by the auth middleware (JwtPlugin).
+//  - `validatedQuery`: the parsed/validated query set by the validateQuery middleware.
+import type { JwtPayload } from "jsonwebtoken";
+import type { PaginationInput } from "../application/validators/users.validators";
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: string | JwtPayload;
+      validatedQuery?: PaginationInput;
+    }
+  }
+}
+
+export {};

--- a/tests/integration/users.integration.test.ts
+++ b/tests/integration/users.integration.test.ts
@@ -63,15 +63,24 @@ describe("GET /api/users", () => {
 // GET /api/users/:id
 // ===========================
 describe("GET /api/users/:id", () => {
-  it("returns 200 with user data for an existing user", async () => {
+  it("returns 401 without Authorization header", async () => {
     const res = await request(app).get("/api/users/1");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 with user data for an existing user when authenticated", async () => {
+    const res = await request(app)
+      .get("/api/users/1")
+      .set("Authorization", `Bearer ${bearerToken}`);
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ id: 1 });
     expect(res.body).toHaveProperty("name");
   });
 
   it("returns 404 for a non-existing user", async () => {
-    const res = await request(app).get("/api/users/9999");
+    const res = await request(app)
+      .get("/api/users/9999")
+      .set("Authorization", `Bearer ${bearerToken}`);
     expect(res.status).toBe(404);
     expect(res.body).toMatchObject({ message: "User not found" });
   });

--- a/tests/setup/test-env.ts
+++ b/tests/setup/test-env.ts
@@ -1,0 +1,4 @@
+// tests/setup/test-env.ts
+// Runs (via jest "setupFiles") before each test module is imported, so the
+// critical secrets validated at DI-container load are present during tests.
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";

--- a/tests/unit/core/config/env.validation.unit.test.ts
+++ b/tests/unit/core/config/env.validation.unit.test.ts
@@ -1,0 +1,44 @@
+import { validateCriticalEnvs } from "../../../../src/core/config/env.validation";
+import { IEnvs } from "../../../../src/domain/interfaces/infrastructure/plugins/envs.plugin.interface";
+
+function envsFrom(values: Record<string, string>): IEnvs {
+  return { getEnv: (key: string) => values[key] ?? "" };
+}
+
+describe("validateCriticalEnvs", () => {
+  it("passes when JWT_SECRET is present (dummy datasource)", () => {
+    expect(() =>
+      validateCriticalEnvs(envsFrom({ JWT_SECRET: "secret" }))
+    ).not.toThrow();
+  });
+
+  it("throws when JWT_SECRET is missing", () => {
+    expect(() => validateCriticalEnvs(envsFrom({}))).toThrow(/JWT_SECRET/);
+  });
+
+  it("requires DB_PASSWORD when DATA_SOURCE=sqlserver", () => {
+    expect(() =>
+      validateCriticalEnvs(envsFrom({ JWT_SECRET: "secret", DATA_SOURCE: "sqlserver" }))
+    ).toThrow(/DB_PASSWORD/);
+  });
+
+  it("passes for sqlserver when DB_PASSWORD is present", () => {
+    expect(() =>
+      validateCriticalEnvs(
+        envsFrom({ JWT_SECRET: "secret", DATA_SOURCE: "sqlserver", DB_PASSWORD: "pw" })
+      )
+    ).not.toThrow();
+  });
+
+  it("does not require DB_PASSWORD for the dummy datasource", () => {
+    expect(() =>
+      validateCriticalEnvs(envsFrom({ JWT_SECRET: "secret", DATA_SOURCE: "dummy" }))
+    ).not.toThrow();
+  });
+
+  it("lists every missing secret in a single error", () => {
+    expect(() =>
+      validateCriticalEnvs(envsFrom({ DATA_SOURCE: "sqlserver" }))
+    ).toThrow(/JWT_SECRET, DB_PASSWORD/);
+  });
+});

--- a/tests/unit/core/di/datasource.factory.unit.test.ts
+++ b/tests/unit/core/di/datasource.factory.unit.test.ts
@@ -1,0 +1,38 @@
+import "reflect-metadata";
+import {
+  resolveUsersDataSource,
+  USERS_DATASOURCES,
+} from "../../../../src/core/di/datasource.factory";
+import { UsersDummyDataSource } from "../../../../src/infrastructure/datasources/dummy/users.dummy.datasource";
+import { UsersSqlServerDataSource } from "../../../../src/infrastructure/datasources/sqlserver/users.sqlserver.datasource";
+
+describe("resolveUsersDataSource", () => {
+  it("defaults to the dummy datasource when no value is provided", () => {
+    expect(resolveUsersDataSource(undefined)).toBe(UsersDummyDataSource);
+    expect(resolveUsersDataSource("")).toBe(UsersDummyDataSource);
+  });
+
+  it("returns the dummy datasource for 'dummy'", () => {
+    expect(resolveUsersDataSource("dummy")).toBe(UsersDummyDataSource);
+  });
+
+  it("returns the SQL Server datasource for 'sqlserver'", () => {
+    expect(resolveUsersDataSource("sqlserver")).toBe(UsersSqlServerDataSource);
+  });
+
+  it("is case-insensitive", () => {
+    expect(resolveUsersDataSource("SqlServer")).toBe(UsersSqlServerDataSource);
+    expect(resolveUsersDataSource("DUMMY")).toBe(UsersDummyDataSource);
+  });
+
+  it("throws a descriptive error for an unknown datasource", () => {
+    expect(() => resolveUsersDataSource("mongodb")).toThrow(
+      /Unknown DATA_SOURCE "mongodb"/
+    );
+    expect(() => resolveUsersDataSource("mongodb")).toThrow(/dummy, sqlserver/);
+  });
+
+  it("exposes the available implementations", () => {
+    expect(Object.keys(USERS_DATASOURCES).sort()).toEqual(["dummy", "sqlserver"]);
+  });
+});

--- a/tests/unit/core/di/logger.factory.unit.test.ts
+++ b/tests/unit/core/di/logger.factory.unit.test.ts
@@ -1,0 +1,48 @@
+import "reflect-metadata";
+import { createLogger } from "../../../../src/core/di/logger.factory";
+import { PinoLoggerPlugin } from "../../../../src/infrastructure/plugins/pino.plugin";
+import { WinstonPlugin } from "../../../../src/infrastructure/plugins/winston.plugin";
+import { IEnvs } from "../../../../src/domain/interfaces/infrastructure/plugins/envs.plugin.interface";
+
+jest.mock("../../../../src/infrastructure/plugins/pino.plugin");
+jest.mock("../../../../src/infrastructure/plugins/winston.plugin");
+
+function envsFrom(values: Record<string, string>): IEnvs {
+  return { getEnv: (key: string) => values[key] ?? "" };
+}
+
+describe("createLogger", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("defaults to Pino when LOG_DRIVER is not set", () => {
+    const logger = createLogger(envsFrom({}));
+    expect(PinoLoggerPlugin).toHaveBeenCalledTimes(1);
+    expect(WinstonPlugin).not.toHaveBeenCalled();
+    expect(logger).toBeInstanceOf(PinoLoggerPlugin);
+  });
+
+  it("returns Pino for LOG_DRIVER=pino", () => {
+    const logger = createLogger(envsFrom({ LOG_DRIVER: "pino" }));
+    expect(PinoLoggerPlugin).toHaveBeenCalled();
+    expect(logger).toBeInstanceOf(PinoLoggerPlugin);
+  });
+
+  it("returns Winston for LOG_DRIVER=winston and forwards level/service", () => {
+    const logger = createLogger(
+      envsFrom({ LOG_DRIVER: "winston", LOG_LEVEL: "info", SERVICE_NAME: "svc" })
+    );
+    expect(WinstonPlugin).toHaveBeenCalledWith({ level: "info", service: "svc" });
+    expect(logger).toBeInstanceOf(WinstonPlugin);
+  });
+
+  it("is case-insensitive for the driver name", () => {
+    createLogger(envsFrom({ LOG_DRIVER: "WINSTON" }));
+    expect(WinstonPlugin).toHaveBeenCalled();
+  });
+
+  it("throws a descriptive error for an unknown LOG_DRIVER", () => {
+    expect(() => createLogger(envsFrom({ LOG_DRIVER: "bunyan" }))).toThrow(
+      /Unknown LOG_DRIVER "bunyan"/
+    );
+  });
+});

--- a/tests/unit/core/server.unit.test.ts
+++ b/tests/unit/core/server.unit.test.ts
@@ -5,6 +5,8 @@ import { Server } from "../../../src/core/server";
 import { container } from "tsyringe";
 import { IEnvs } from "../../../src/domain/interfaces/infrastructure/plugins/envs.plugin.interface";
 import { ILogger } from "../../../src/domain/interfaces/infrastructure/plugins/logger.plugin.interface";
+import { ITokenPlugin } from "../../../src/domain/interfaces/infrastructure/plugins/token.plugin.interface";
+import { JwtPlugin } from "../../../src/infrastructure/plugins/jwt.plugin";
 
 jest.mock("swagger-jsdoc", () => jest.fn(() => ({ openapi: "3.0.0" })));
 jest.mock("swagger-ui-express", () => ({
@@ -36,6 +38,8 @@ describe("Server", () => {
         },
       },
     });
+
+    container.register<ITokenPlugin>("ITokenPlugin", { useClass: JwtPlugin });
 
     container.register("IUsersController", {
       useValue: {

--- a/tests/unit/infrastructure/plugins/jwt.plugin.unit.test.ts
+++ b/tests/unit/infrastructure/plugins/jwt.plugin.unit.test.ts
@@ -14,6 +14,11 @@ describe("JWTPlugin", () => {
     jwtPlugin = new JwtPlugin(mockEnvs);
   });
 
+  it("should throw if JWT_SECRET is not set (no insecure default)", () => {
+    const envsWithoutSecret: IEnvs = { getEnv: () => "" };
+    expect(() => new JwtPlugin(envsWithoutSecret)).toThrow(/JWT_SECRET is not set/);
+  });
+
   it("should create a token string", () => {
     const token = jwtPlugin.generateToken({ userId: 1 });
     expect(typeof token).toBe("string");

--- a/tests/unit/infrastructure/plugins/jwt.plugin.unit.test.ts
+++ b/tests/unit/infrastructure/plugins/jwt.plugin.unit.test.ts
@@ -1,4 +1,3 @@
-import { container } from "tsyringe";
 import { JwtPlugin } from "../../../../src/infrastructure/plugins/jwt.plugin";
 import { Request, Response, NextFunction } from 'express';
 import { IEnvs } from "../../../../src/domain/interfaces/infrastructure/plugins/envs.plugin.interface";
@@ -6,21 +5,13 @@ import { IEnvs } from "../../../../src/domain/interfaces/infrastructure/plugins/
 describe("JWTPlugin", () => {
   let jwtPlugin: JwtPlugin;
 
+  // Mock de IEnvs inyectado por constructor (sin service locator)
+  const mockEnvs: IEnvs = {
+    getEnv: (key: string) => (key === "JWT_SECRET" ? "unit-test-secret" : ""),
+  };
+
   beforeEach(() => {
-    container.reset();
-
-    // Mock de IEnvs para devolver siempre un JWT_SECRET
-    container.register<IEnvs>("IEnvs", {
-      useValue: {
-        getEnv: (key: string) => {
-          if (key === "JWT_SECRET") return "unit-test-secret";
-          return "";
-        },
-      },
-    });
-
-    // ✅ Ahora sí instanciamos el JwtPlugin después del registro
-    jwtPlugin = new JwtPlugin();
+    jwtPlugin = new JwtPlugin(mockEnvs);
   });
 
   it("should create a token string", () => {

--- a/tests/unit/infrastructure/plugins/sequelize.plugin.unit.test.ts
+++ b/tests/unit/infrastructure/plugins/sequelize.plugin.unit.test.ts
@@ -1,22 +1,36 @@
 
 import { QueryTypes, Transaction } from "sequelize";
 import { SequelizePlugin  } from "../../../../src/infrastructure/plugins/sequelize.plugin";
+import { ILogger } from "../../../../src/domain/interfaces/infrastructure/plugins/logger.plugin.interface";
 
 describe("SequelizePlugin (unit tests with mocks - MSSQL)", () => {
   let plugin: SequelizePlugin;
   let mockQuery: jest.Mock;
+  let mockLogger: jest.Mocked<ILogger>;
 
   beforeEach(() => {
     mockQuery = jest.fn();
 
-    plugin = new SequelizePlugin({
-      dialect: "mssql",
-      host: "localhost",
-      port: 1433,
-      username: "sa",
-      password: "yourStrong(!)Password",
-      database: "testdb",
-    });
+    mockLogger = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      log: jest.fn(),
+      http: jest.fn(),
+    };
+
+    plugin = new SequelizePlugin(
+      {
+        dialect: "mssql",
+        host: "localhost",
+        port: 1433,
+        username: "sa",
+        password: "yourStrong(!)Password",
+        database: "testdb",
+      },
+      mockLogger
+    );
 
     // Sobreescribimos la conexión real con mocks
     (plugin as any).connection = {
@@ -31,8 +45,23 @@ describe("SequelizePlugin (unit tests with mocks - MSSQL)", () => {
     };
   });
 
-  it("should authenticate without errors", async () => {
+  it("should authenticate without errors and log via the injected logger", async () => {
     await expect(plugin.authenticate()).resolves.not.toThrow();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "Database connection established successfully."
+    );
+  });
+
+  it("should log the error and rethrow when authenticate fails", async () => {
+    (plugin as any).connection.authenticate = jest
+      .fn()
+      .mockRejectedValue(new Error("connection refused"));
+
+    await expect(plugin.authenticate()).rejects.toThrow("Database connection failed.");
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Unable to connect to the database",
+      expect.objectContaining({ error: expect.any(Error) })
+    );
   });
 
   it("should run getDataTable and return rows", async () => {

--- a/tests/unit/infrastructure/plugins/winston.plugin.unit.test.ts
+++ b/tests/unit/infrastructure/plugins/winston.plugin.unit.test.ts
@@ -180,6 +180,15 @@ describe("WinstonPlugin", () => {
     expect(winston.transports.File).toHaveBeenCalled();
   });
 
+  it("should honor the level passed through options", () => {
+    (winston.createLogger as jest.Mock).mockClear();
+    new WinstonPlugin({ level: "debug", service: "svc" });
+
+    expect(winston.createLogger).toHaveBeenCalledWith(
+      expect.objectContaining({ level: "debug", defaultMeta: { service: "svc" } })
+    );
+  });
+
   // =========================
   // ✅ Console transport formatter (branch coverage)
   // =========================

--- a/tests/unit/routes/test.route.unit.test.ts
+++ b/tests/unit/routes/test.route.unit.test.ts
@@ -2,6 +2,8 @@ import request from "supertest";
 import express from "express";
 import { container } from "tsyringe";
 import { IEnvs } from "../../../src/domain/interfaces/infrastructure/plugins/envs.plugin.interface";
+import { ITokenPlugin } from "../../../src/domain/interfaces/infrastructure/plugins/token.plugin.interface";
+import { JwtPlugin } from "../../../src/infrastructure/plugins/jwt.plugin";
 import { S3FileStoragePlugin } from "../../../src/infrastructure/plugins/s3FileStorage.plugin";
 import { TestRoutes } from "../../../src/presentation/routes/test.route";
 
@@ -24,6 +26,9 @@ describe("TestRoutes (unit)", () => {
         },
       },
     });
+
+    // El plugin de token se resuelve por DI desde las rutas
+    container.register<ITokenPlugin>("ITokenPlugin", { useClass: JwtPlugin });
 
     // Mock de S3FileStoragePlugin
     (S3FileStoragePlugin as jest.Mock).mockImplementation(() => ({

--- a/tests/unit/services/users.service.unit.test.ts
+++ b/tests/unit/services/users.service.unit.test.ts
@@ -108,14 +108,34 @@ describe("UsersService Unit Tests", () => {
   // ======================================
   // updateUser
   // ======================================
-  it("should update a user (DTO → Model)", async () => {
+  it("should update a user mapping only the present fields (no pkUser in the change set)", async () => {
     mockRepository.updateUser.mockResolvedValue(true);
 
     const dto: UserDTO = { id: 1, name: "Updated User" };
     const result = await usersService.updateUser(1, dto);
 
     expect(result).toBe(true);
-    expect(mockRepository.updateUser).toHaveBeenCalledWith(1, { pkUser: 1, name: "Updated User" });
+    expect(mockRepository.updateUser).toHaveBeenCalledWith(1, { name: "Updated User" });
+  });
+
+  it("should not invent a pkUser 0 nor a name when updating with an empty payload", async () => {
+    mockRepository.updateUser.mockResolvedValue(true);
+
+    const result = await usersService.updateUser(5, {});
+
+    expect(result).toBe(true);
+    expect(mockRepository.updateUser).toHaveBeenCalledWith(5, {});
+    const [, partial] = mockRepository.updateUser.mock.calls[0];
+    expect(partial).not.toHaveProperty("pkUser");
+    expect(partial).not.toHaveProperty("name");
+  });
+
+  it("should map only the name on a partial update", async () => {
+    mockRepository.updateUser.mockResolvedValue(true);
+
+    await usersService.updateUser(7, { name: "Only Name" });
+
+    expect(mockRepository.updateUser).toHaveBeenCalledWith(7, { name: "Only Name" });
   });
 
   // ======================================


### PR DESCRIPTION
Corrige una serie de defectos concretos sin reescribir la arquitectura ni cambiar la estructura de carpetas. Commits pequeños por cada fix; `npm run lint` y `npm test` en verde (144 → **167 tests**).

## Cambios por punto

**1. Selección de datasource por `DATA_SOURCE` (alta)**
- Nuevo `core/di/datasource.factory.ts` (`resolveUsersDataSource`): mapea `"dummy" | "sqlserver"` (default `dummy`) y falla ruidosamente ante valores desconocidos.
- El contenedor usa el factory; eliminados los imports muertos (`UsersSqlServerDataSource`, `path`).
- Documentado en `.env.template`, `.env.dev`, `docs/environment.md`. Test añadido.

**2. JWT por inyección de dependencias (alta)**
- `JwtPlugin` recibe `IEnvs` por constructor (`@inject`); eliminado el `container.resolve` interno (service locator).
- `users.route.ts` y `test.route.ts` resuelven `ITokenPlugin` desde el contenedor (no `new`).

**3. Secretos por defecto inseguros eliminados (alta)**
- Fuera `JWT_SECRET || "super-secret-key"` y `DB_PASSWORD || "StrongPassword123!"`.
- Nuevo `core/config/env.validation.ts` (`validateCriticalEnvs`) ejecutado al arrancar: exige `JWT_SECRET` siempre y `DB_PASSWORD` solo con `DATA_SOURCE=sqlserver`. `JwtPlugin` también lanza si falta el secreto.
- Setup de Jest provee `JWT_SECRET` (el import del contenedor se hoistea).

**4. Auth consistente en rutas**
- `GET /users/:id` ahora aplica el middleware JWT; anotación `@openapi` ajustada (`security` + `401`). Integration test actualizado.

**5. Quitar `any` en capa de datos y Request**
- `ISqlConnectionPlugin` / `SequelizePlugin`: genéricos (`TRow`/`TMeta`) en `getDataTable`/`executeQuery`/`execStoredProcedure`.
- `users.sqlserver.datasource.ts`: tipo `UsersTableRow` (sin `row: any`) y catch sin `any`.
- Nuevo `src/types/express.d.ts` (declaration merging) tipa `req.user` y `req.validatedQuery`; eliminados los `(req as any)`.

**6. Logging coherente en la capa de datos**
- `SequelizePlugin` usa el `ILogger` inyectado (Pino); sin `console.*` ni emojis en el data layer.

**7. Winston arreglado y conmutable (no borrado)**
- Por indicación del autor, en vez de borrar Winston se arregló y se dejó conmutable: nuevo `core/di/logger.factory.ts` (`createLogger`) selecciona `pino` (default) / `winston` vía `LOG_DRIVER`. `WinstonPlugin` ahora lee nivel de opts/`LOG_LEVEL` (antes hardcodeado), etiqueta `service` y usa `logDir` de `cwd`. `winston` se mantiene en dependencias.

**8. Update parcial seguro en el service**
- `updateUser` mapea solo los campos presentes (`toPartialModel`), sin cast forzado ni `pkUser: 0` ni `name: undefined`. El `id` de la ruta identifica al usuario.

## Decisiones / supuestos
- **Punto 7 reinterpretado** según la instrucción final: Winston se arregla y se deja conmutable, no se borra.
- `req.validatedQuery` tipado como `PaginationInput` (su único uso); cast localizado y comentado en `validateQuery`.
- `console.*` restantes en infra dejados a propósito: `dotenv.plugin` (corre antes del logger) y el fallback de `pino-pretty` dentro del propio logger — no son la capa de datos ni pueden usar el `ILogger` inyectado sin circularidad.
- `.env.template`/docs: `DB_PASSWORD` de ejemplo cambiado a `change_me` para no enviar un secreto con aspecto real.
- Incluidos dos arreglos menores que el propio `npm run lint --fix` exige (punto y coma en `IFileStorage`, comillas en `swagger.config.ts`) para dejar el árbol limpio tras lintar.
- README actualizado con `DATA_SOURCE`/`LOG_DRIVER` y el comportamiento fail-fast.

## Verificación
- `npm run lint` → 0 errores (17 warnings pre-existentes; `no-explicit-any` es `warn` a propósito en el proyecto).
- `npm test` → 22 suites, 167 tests, thresholds de cobertura OK.

> No se tocó la estructura de capas ni se renombraron archivos.
